### PR TITLE
fix: Unnecessary worker initialization if queue of task is empty in dynamic spawning mode

### DIFF
--- a/lib/src/scheduling/executor.dart
+++ b/lib/src/scheduling/executor.dart
@@ -41,7 +41,7 @@ class _Executor extends Mixinable<_Executor> with _ExecutorLogger {
   Future<void> dispose() async {
     _queue.clear();
     for (final worker in _pool) {
-      if (worker.taskId != null) {
+      if (worker.initialized) {
         worker.kill();
       }
     }

--- a/lib/src/scheduling/executor.dart
+++ b/lib/src/scheduling/executor.dart
@@ -197,7 +197,10 @@ class _Executor extends Mixinable<_Executor> with _ExecutorLogger {
       _ensureWorkersInitialized();
       return;
     }
-    if (_queue.isEmpty) return;
+    if (_queue.isEmpty) {
+      if (_dynamicSpawning) availableWorker.kill();
+      return;
+    }
     final task = _queue.removeFirst();
 
     availableWorker

--- a/lib/src/scheduling/executor.dart
+++ b/lib/src/scheduling/executor.dart
@@ -13,6 +13,9 @@ class _Executor extends Mixinable<_Executor> with _ExecutorLogger {
   var _dynamicSpawning = false;
   var _isolatesCount = numberOfProcessors;
 
+  @visibleForTesting
+  List<Worker> get pool => List.unmodifiable(_pool);
+
   @override
   Future<void> init({int? isolatesCount, bool? dynamicSpawning}) async {
     if (_pool.isNotEmpty) {
@@ -38,7 +41,9 @@ class _Executor extends Mixinable<_Executor> with _ExecutorLogger {
   Future<void> dispose() async {
     _queue.clear();
     for (final worker in _pool) {
-      worker.kill();
+      if (worker.taskId != null) {
+        worker.kill();
+      }
     }
     _pool.clear();
     super.dispose();

--- a/test/dynamic_spawning_memory_leak_test.dart
+++ b/test/dynamic_spawning_memory_leak_test.dart
@@ -1,0 +1,20 @@
+// ignore_for_file: invalid_use_of_visible_for_testing_member
+import 'package:test/test.dart';
+import 'package:worker_manager/worker_manager.dart';
+
+void main() {
+  setUp(() async => await workerManager.dispose());
+  tearDown(() async => await workerManager.dispose());
+
+  test('init() kills idle worker when dynamicSpawning=true and no tasks queued',
+      () async {
+    await workerManager.init(dynamicSpawning: true);
+
+    expect(
+      workerManager.pool.every((w) => !w.initialized),
+      isTrue,
+      reason:
+          'init() must not leave idle workers alive when dynamicSpawning=true',
+    );
+  });
+}

--- a/test/dynamic_spawning_memory_leak_test.dart
+++ b/test/dynamic_spawning_memory_leak_test.dart
@@ -10,6 +10,7 @@ void main() {
       () async {
     await workerManager.init(dynamicSpawning: true);
 
+    expect(workerManager.pool.isNotEmpty, isTrue);
     expect(
       workerManager.pool.every((w) => !w.initialized),
       isTrue,


### PR DESCRIPTION
### Why?
- When `workerManager.init()` is called, `_schedule` is called without anything in `_queue`.
- Even if `_queue` is empty, a worker is already created with:

https://github.com/linagora/worker_manager/blob/247849b50c3c568a1e502aec0b8433ba82021ce6/lib/src/scheduling/executor.dart#L33

- So when `workerManager.init()` is called, `_schedule` stopped at:

https://github.com/linagora/worker_manager/blob/247849b50c3c568a1e502aec0b8433ba82021ce6/lib/src/scheduling/executor.dart#L200

- Even if `_dynamicSpawning` is true, that created worker is not disposed. It will only be dispose when a task is execute, which maybe a long time, wasting users' device's memory